### PR TITLE
Fixed millis() overflow on SNTP reply

### DIFF
--- a/src/mgos_arduino.cpp
+++ b/src/mgos_arduino.cpp
@@ -54,11 +54,11 @@ void delayMicroseconds(unsigned int us) {
 }
 
 unsigned long millis(void) {
-  return mg_time() * 1000;
+  return mgos_uptime() * 1000;
 }
 
 unsigned long micros(void) {
-  return mg_time() * 1000000;
+  return mgos_uptime() * 1000000;
 }
 
 void interrupts(void) {


### PR DESCRIPTION
mg_time() gets updated to a very large number after an SNTP reply, which results in an overflow when converting from double to long. Using mgos_uptime() instead should fix this.