### PR TITLE
included `mgos_time.h` because `mgos_uptime` moved to `mgos_time`

### DIFF
--- a/src/mgos_arduino.cpp
+++ b/src/mgos_arduino.cpp
@@ -15,8 +15,8 @@
 #include "mgos_gpio.h"
 #include "mgos_hal.h"
 #include "mgos_init.h"
-#include "mgos_timers.h"
 #include "mgos_time.h"
+#include "mgos_timers.h"
 
 #ifndef IRAM
 #define IRAM

--- a/src/mgos_arduino.cpp
+++ b/src/mgos_arduino.cpp
@@ -16,6 +16,7 @@
 #include "mgos_hal.h"
 #include "mgos_init.h"
 #include "mgos_timers.h"
+#include "mgos_time.h"
 
 #ifndef IRAM
 #define IRAM


### PR DESCRIPTION
[https://github.com/cesanta/mongoose-os/commit/88a03736d21c2abfe3c9e8cf64a9ea9f4fcd8dae] - moves the `mgos_uptime` function to `mgos_time.h`